### PR TITLE
Fix overwritten SDK version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dwave-ocean-sdk>=4.2.1
+dwave-ocean-sdk>=4.3.0
 
 jupyter
 jupyter_contrib_nbextensions


### PR DESCRIPTION
I rebased and accidently overwrote the update in https://github.com/dwave-examples/reverse-annealing-notebook/pull/6. SDK version 4.3.0 has the TilingComposite.