### PR TITLE
Update xrefs to docs for new URLs

### DIFF
--- a/01-reverse-annealing.ipynb
+++ b/01-reverse-annealing.ipynb
@@ -28,7 +28,7 @@
    "source": [
     "# The Reverse Anneal Feature\n",
     "\n",
-    "The [Getting Started with the D-Wave System](https://docs.dwavesys.com/docs/latest/doc_getting_started.html) document describes quantum annealing and the [Solver Properties and Parameters](https://docs.dwavesys.com/docs/latest/doc_solver_ref.html) book describes the parameters used here.\n",
+    "The [What is Quantum Annealing?](https://docs.dwavequantum.com/en/latest/quantum_research/quantum_annealing_intro.html) page describes quantum annealing and the [QPU Solver Parameters](https://docs.dwavequantum.com/en/latest/quantum_research/solver_parameters.html) page describes the parameters used here.\n",
     "\n",
     "In brief, reverse annealing is a technique that makes it possible to refine known good local solutions, thereby increasing performance for certain applications. It comprises (1) annealing backward from a known classical state to a mid-anneal state of quantum superposition, (2) searching for optimum solutions at this mid-anneal point while in the presence of an increased transverse field (quantum state), and then (3) proceeding forward to a new classical state at the end of the anneal.\n",
     "\n",
@@ -51,7 +51,7 @@
    "source": [
     "## Feature Availability\n",
     "\n",
-    "Availability of the reverse anneal feature depends on the solver you connect to. This subsection checks whether your solver supports this feature by querying solver property `max_anneal_schedule_points`  and ensuring it is at least 4---see the [Solver Properties and Parameters](https://docs.dwavesys.com/docs/latest/doc_solver_ref.html) book for a description of the anneal schedule and the requirements for supporting this feature. \n",
+    "Availability of the reverse anneal feature depends on the solver you connect to. This subsection checks whether your solver supports this feature by querying solver property `max_anneal_schedule_points`  and ensuring it is at least 4---see the [General QPU Solver Properties](https://docs.dwavequantum.com/en/latest/quantum_research/solver_properties_all.html) page for a description of the anneal schedule and the requirements for supporting this feature. \n",
     "\n",
     "The first cell below sets up a connection to the quantum processing unit (QPU). The second cell checks the number of anneal-schedule points supported and also checks the annealing time range (in μs) and maximum slope (slopes of each line segment of an anneal schedule must not violate the maximum slope).\n",
     "\n",
@@ -253,7 +253,7 @@
     "## Generating the 16-Bit Problem\n",
     "The structure of this problem maps neatly to the Chimera topology of a D-Wave 2000Q QPU: it can be minor-embedded directly into two side-by-side Chimera unit cells, with each problem qubit represented by one qubit on the QPU. On Advantage systems, the problem can be similarly represented by qubits in two of the Chimera unit cell's near-counterpart structure in the Pegasus topology: $K_{4,4}$ bicliques with additional *odd* couplers.\n",
     "\n",
-    "If you were to use a standard heuristic embedder such as [minorminer](https://docs.ocean.dwavesys.com/en/stable/docs_minorminer/source/sdk_index.html), however, some of the problem qubits might be represented by chains of qubits on the QPU. Instead, qubits of two ideal Chimera unit cells are used directly in the `h` and `J` definitions below and the `TilingComposite` composite scans adjacent unit cells on the QPU, finds adjacent pairs in which all the required qubits and couplers are available, and translates the one-to-one minor-embedding of the problem from the first two adjacent pairs to the first available valid pairs."
+    "If you were to use a standard heuristic embedder such as [minorminer](https://docs.dwavequantum.com/en/latest/ocean/api_ref_minorminer/source/index.html), however, some of the problem qubits might be represented by chains of qubits on the QPU. Instead, qubits of two ideal Chimera unit cells are used directly in the `h` and `J` definitions below and the `TilingComposite` composite scans adjacent unit cells on the QPU, finds adjacent pairs in which all the required qubits and couplers are available, and translates the one-to-one minor-embedding of the problem from the first two adjacent pairs to the first available valid pairs."
    ]
   },
   {

--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ recommended.
 ## Usage
 
 Your development environment should be configured to 
-[access Leap’s Solvers](https://docs.ocean.dwavesys.com/en/stable/overview/sapi.html).
+[access Leap’s Solvers](https://docs.dwavequantum.com/en/latest/ocean/sapi_access_basic.html).
 You can see information about supported IDEs and authorizing access to your 
-Leap account [here](https://docs.dwavesys.com/docs/latest/doc_leap_dev_env.html).  
+Leap account [here](https://docs.dwavequantum.com/en/latest/leap_sapi/dev_env.html).  
 
 The notebook can be opened by clicking on the 
 ``01-reverse-annealing.ipynb`` file in VS Code-based IDEs. 

--- a/README.md
+++ b/README.md
@@ -9,49 +9,50 @@
 
 This notebook explains and demonstrates the reverse-anneal feature.
 
-Reverse annealing is a technique that makes it possible to refine known good local
-solutions, thereby increasing performance for certain applications. It comprises
-(1) annealing backward from a known classical state to a mid-anneal state of
-quantum superposition, (2) searching for optimum solutions at this mid-anneal
-point while in the presence of an increased transverse field (quantum state), and
-then (3) proceeding forward to a new classical state at the end of the anneal.
+Reverse annealing is a technique that makes it possible to refine known good
+local solutions, thereby increasing performance for certain applications. It
+comprises (1) annealing backward from a known classical state to a mid-anneal
+state of quantum superposition, (2) searching for optimum solutions at this
+mid-anneal point while in the presence of an increased transverse field (quantum
+state), and then (3) proceeding forward to a new classical state at the end of
+the anneal.
 
 The notebook has the following sections:
 
-1. **The Reverse Anneal Feature** explains the feature and its parameters.
-2. **Using the Reverse Anneal Feature** demonstrates the use of the feature on a
-   random example problem.
-3. **Analysis on a 16-Bit Problem** uses reverse annealing on a known problem and
-   compares the results with other anneal methods.
-4. **Modulating the Reverse-Annealing Parameters** provides code that lets you
-   sweep through various anneal schedules to explore the effect on results.
+1.  **The Reverse Anneal Feature** explains the feature and its parameters.
+2.  **Using the Reverse Anneal Feature** demonstrates the use of the feature on
+    a random example problem.
+3.  **Analysis on a 16-Bit Problem** uses reverse annealing on a known problem
+    and compares the results with other anneal methods.
+4.  **Modulating the Reverse-Annealing Parameters** provides code that lets you
+    sweep through various anneal schedules to explore the effect on results.
 
 ![energy](images/16q_energy.png)
 
 ## Installation
 
-You can run this example without installation in cloud-based IDEs that support 
+You can run this example without installation in cloud-based IDEs that support
 the [Development Containers specification](https://containers.dev/supporting)
 (aka "devcontainers").
 
-For development environments that do not support ``devcontainers``, install 
+For development environments that do not support ``devcontainers``, install
 requirements:
 
     pip install -r requirements.txt
 
-If you are cloning the repo to your local system, working in a 
-[virtual environment](https://docs.python.org/3/library/venv.html) is 
+If you are cloning the repo to your local system, working in a
+[virtual environment](https://docs.python.org/3/library/venv.html) is
 recommended.
 
 ## Usage
 
-Your development environment should be configured to 
+Your development environment should be configured to
 [access Leap’s Solvers](https://docs.dwavequantum.com/en/latest/ocean/sapi_access_basic.html).
-You can see information about supported IDEs and authorizing access to your 
-Leap account [here](https://docs.dwavequantum.com/en/latest/leap_sapi/dev_env.html).  
+You can see information about supported IDEs and authorizing access to your Leap
+account [here](https://docs.dwavequantum.com/en/latest/leap_sapi/dev_env.html).
 
-The notebook can be opened by clicking on the 
-``01-reverse-annealing.ipynb`` file in VS Code-based IDEs. 
+The notebook can be opened by clicking on the
+``01-reverse-annealing.ipynb`` file in VS Code-based IDEs.
 
 To run a locally installed notebook:
 


### PR DESCRIPTION
[This commit](https://github.com/dwave-examples/reverse-annealing-notebook/commit/c454e90687bd61dd2b66c35a97dfbd65bfd9109e) has the URL updates and is easier to review without the noise of the [2nd commit](https://github.com/dwave-examples/reverse-annealing-notebook/commit/9a393336469c95c880864ae12b1d475e09203897).